### PR TITLE
Skip CI test steps when no Go files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Makefile'
+              - '.github/workflows/ci.yml'
+
       - uses: actions/setup-go@v5
+        if: steps.changes.outputs.go == 'true'
         with:
           go-version-file: go.mod
 
       - name: Vet
+        if: steps.changes.outputs.go == 'true'
         run: go vet ./...
 
       - name: Test
+        if: steps.changes.outputs.go == 'true'
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Build
+        if: steps.changes.outputs.go == 'true'
         run: go build -o /dev/null .


### PR DESCRIPTION
## Summary
- Uses `dorny/paths-filter` to detect Go-related file changes
- Test job always runs (satisfies branch ruleset), but skips expensive steps (setup-go, vet, test, build) when only non-Go files are modified
- Triggers on: `**/*.go`, `go.mod`, `go.sum`, `Makefile`, `.github/workflows/ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)