### PR TITLE
Fix README: MCP server requires 'mcp' subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Add to your project's `.mcp.json`:
   "mcpServers": {
     "tasks": {
       "type": "stdio",
-      "command": "tasks-mcp"
+      "command": "tasks-mcp",
+      "args": ["mcp"]
     }
   }
 }
@@ -57,7 +58,7 @@ Add to your project's `.mcp.json`:
     "tasks": {
       "type": "stdio",
       "command": "docker",
-      "args": ["run", "--rm", "-i", "-v", "tasks-mcp-data:/data", "ghcr.io/freeformz/tasks-mcp:latest"]
+      "args": ["run", "--rm", "-i", "-v", "tasks-mcp-data:/data", "ghcr.io/freeformz/tasks-mcp:latest", "mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Updates `.mcp.json` examples to include `"args": ["mcp"]` since the server now starts via `tasks-mcp mcp`
- Fixes both the native install and Docker examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)