### PR TITLE
Broaden docs-update rule path filter

### DIFF
--- a/.claude/rules/docs-update.md
+++ b/.claude/rules/docs-update.md
@@ -1,0 +1,12 @@
+---
+paths:
+  - "**/*.go"
+  - "go.mod"
+  - "Makefile"
+  - "hooks/**"
+  - ".goreleaser.yml"
+---
+
+## Keep docs in sync
+
+When changing CLI args, commands, configuration, MCP tools, or user-facing behavior, check and update `README.md` and `docs/PRD.md` to reflect the changes.


### PR DESCRIPTION
## Summary
- Expands `.claude/rules/docs-update.md` path filter to cover more files that could affect user-facing behavior
- Paths: `**/*.go`, `go.mod`, `Makefile`, `hooks/**`, `.goreleaser.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)