### PR TITLE
Fix MCPB manifest to pass mcp subcommand

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     "entry_point": "server/tasks-mcp",
     "mcp_config": {
       "command": "${__dirname}/server/tasks-mcp",
-      "args": [],
+      "args": ["mcp"],
       "env": {}
     }
   },


### PR DESCRIPTION
## Summary

- Adds `"mcp"` to the `args` array in `manifest.json` so Claude Desktop invokes `tasks-mcp mcp` instead of bare `tasks-mcp`
- Without the subcommand, Cobra prints help text to stdout which the MCP client rejects as invalid JSON

## Test plan

- [ ] Install v0.6.0 MCPB bundle in Claude Desktop and verify no JSON parse errors
- [ ] Verify MCP tools (task_create, task_list, etc.) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)