### PR TITLE
Simplify hooks: deduplicate, reduce DB queries, remove dead code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,17 @@ jobs:
         if: steps.changes.outputs.go == 'true'
         run: go test -race -coverprofile=coverage.out ./...
 
+      - name: Check coverage
+        if: steps.changes.outputs.go == 'true'
+        run: |
+          coverage=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
+          echo "Total coverage: ${coverage}%"
+          threshold=70
+          if [ "$(echo "$coverage < $threshold" | bc -l)" -eq 1 ]; then
+            echo "::error::Coverage ${coverage}% is below the ${threshold}% threshold"
+            exit 1
+          fi
+
       - name: Build
         if: steps.changes.outputs.go == 'true'
         run: go build -o /dev/null .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ make release-snapshot   # local goreleaser build (no publish)
 - Create a feature branch, make changes, push, and open a PR
 - CI must pass before merging
 - Merge via GitHub PR (squash, merge, or rebase — all allowed)
-- Copilot automatically starts a review when new commits are pushed to a PR — no need to manually re-request
+- Copilot automatically starts a review when new commits are pushed to a PR — if no review appears ~2 minutes after push, manually request one with `gh pr edit <N> --add-reviewer "@copilot"`
 - Delete the feature branch after merging
 
 ## Releases

--- a/db.go
+++ b/db.go
@@ -416,10 +416,6 @@ func (d *DB) CheckDependencies(workspace, taskID string) ([]Task, error) {
 	return incomplete, rows.Err()
 }
 
-func (d *DB) PendingSummary(workspace string) ([]Task, error) {
-	return d.ListTasks(workspace, ListFilter{})
-}
-
 func (d *DB) HasActiveTasks(workspace string) (bool, error) {
 	var count int
 	err := d.db.QueryRow(

--- a/db.go
+++ b/db.go
@@ -416,14 +416,6 @@ func (d *DB) CheckDependencies(workspace, taskID string) ([]Task, error) {
 	return incomplete, rows.Err()
 }
 
-func (d *DB) HasActiveTasks(workspace string) (bool, error) {
-	var count int
-	err := d.db.QueryRow(
-		`SELECT COUNT(*) FROM tasks WHERE workspace = ? AND status = 'in_progress'`, workspace,
-	).Scan(&count)
-	return count > 0, err
-}
-
 func (d *DB) enrichTaskMetadata(t *Task) error {
 	tags, err := d.queryStrings(`SELECT tag FROM task_tags WHERE task_id = ? ORDER BY tag`, t.ID)
 	if err != nil {

--- a/db_test.go
+++ b/db_test.go
@@ -1273,18 +1273,3 @@ func TestSubtasksEnrichedWithNotes(t *testing.T) {
 		t.Errorf("expected subtask note 'child note', got %v", got.Subtasks[0].Notes)
 	}
 }
-
-func TestPendingSummary(t *testing.T) {
-	db := testDB(t)
-
-	db.CreateTask(testWorkspace, "Todo", "", StatusTodo, PriorityMedium, "", "", nil, nil)
-	db.CreateTask(testWorkspace, "Done", "", StatusDone, PriorityMedium, "", "", nil, nil)
-
-	tasks, err := db.PendingSummary(testWorkspace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(tasks) != 1 {
-		t.Fatalf("got %d tasks, want 1", len(tasks))
-	}
-}

--- a/db_test.go
+++ b/db_test.go
@@ -615,27 +615,6 @@ func TestCheckDependencies_NoDeps(t *testing.T) {
 	}
 }
 
-func TestHasActiveTasks(t *testing.T) {
-	db := testDB(t)
-
-	has, err := db.HasActiveTasks(testWorkspace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if has {
-		t.Error("expected no active tasks")
-	}
-
-	db.CreateTask(testWorkspace, "Active", "", StatusInProgress, PriorityMedium, "", "", nil, nil)
-
-	has, err = db.HasActiveTasks(testWorkspace)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !has {
-		t.Error("expected active tasks")
-	}
-}
 
 func TestCheckCycle_SelfDependency(t *testing.T) {
 	db := testDB(t)

--- a/hooks.go
+++ b/hooks.go
@@ -198,7 +198,6 @@ func hooksCheckActiveCmd() *cobra.Command {
 			}
 
 			if len(tasks) > 0 {
-
 				result := map[string]any{
 					"decision": "block",
 					"reason":   formatActiveTasksReminder(tasks),

--- a/hooks.go
+++ b/hooks.go
@@ -89,15 +89,11 @@ func hooksSnapshotCmd() *cobra.Command {
 
 // writeSnapshot formats and writes the task snapshot to w.
 func writeSnapshot(w io.Writer, tasks []Task, agentType string) {
-	// Count tasks by status.
+	// Count tasks by status and separate into categories in a single pass.
 	counts := make(map[TaskStatus]int)
-	for _, t := range tasks {
-		counts[t.Status]++
-	}
-
-	// Separate assigned tasks (if agent_type is present) from the rest.
 	var assigned, inProgress, other []Task
 	for _, t := range tasks {
+		counts[t.Status]++
 		if agentType != "" && t.Assignee == agentType {
 			assigned = append(assigned, t)
 		} else if t.Status == StatusInProgress {
@@ -196,16 +192,12 @@ func hooksCheckActiveCmd() *cobra.Command {
 			}
 			defer db.Close()
 
-			hasActive, err := db.HasActiveTasks(input.CWD)
+			tasks, err := db.ListTasks(input.CWD, ListFilter{Status: string(StatusInProgress)})
 			if err != nil {
 				return err
 			}
 
-			if hasActive {
-				tasks, err := db.ListTasks(input.CWD, ListFilter{Status: string(StatusInProgress)})
-				if err != nil {
-					return err
-				}
+			if len(tasks) > 0 {
 
 				result := map[string]any{
 					"decision": "block",

--- a/hooks_test.go
+++ b/hooks_test.go
@@ -152,25 +152,27 @@ func TestHooksCheckActive_BlocksOnActiveTasks(t *testing.T) {
 	db := testDB(t)
 	workspace := "/test/check-active"
 
-	hasActive, err := db.HasActiveTasks(workspace)
+	// No active tasks initially.
+	tasks, err := db.ListTasks(workspace, ListFilter{Status: string(StatusInProgress)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hasActive {
+	if len(tasks) != 0 {
 		t.Error("expected no active tasks")
 	}
 
+	// Create an in-progress task.
 	_, err = db.CreateTask(workspace, "Active task", "", StatusInProgress, PriorityMedium, "", "", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	hasActive, err = db.HasActiveTasks(workspace)
+	tasks, err = db.ListTasks(workspace, ListFilter{Status: string(StatusInProgress)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !hasActive {
-		t.Error("expected active tasks")
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 active task, got %d", len(tasks))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -75,22 +75,7 @@ func mcpCmd() *cobra.Command {
 }
 
 func printTask(t Task) {
-	priority := ""
-	if t.Priority == PriorityHigh || t.Priority == PriorityCritical {
-		priority = fmt.Sprintf(" [%s]", strings.ToUpper(string(t.Priority)))
-	}
-	tags := ""
-	if len(t.Tags) > 0 {
-		tags = fmt.Sprintf(" (%s)", strings.Join(t.Tags, ", "))
-	}
-	assignee := ""
-	if t.Assignee != "" {
-		assignee = fmt.Sprintf(" @%s", t.Assignee)
-	}
-	fmt.Printf("- [%s] %s%s%s%s (id: %s)\n", t.Status, t.Title, priority, tags, assignee, t.ID)
-	for _, st := range t.Subtasks {
-		fmt.Printf("  - [%s] %s (id: %s)\n", st.Status, st.Title, st.ID)
-	}
+	printTaskTo(os.Stdout, t)
 }
 
 func formatActiveTasksReminder(tasks []Task) string {


### PR DESCRIPTION
## Summary
- Deduplicate `printTask`/`printTaskTo`: `printTask` now wraps `printTaskTo(os.Stdout)` instead of duplicating all formatting logic
- Eliminate redundant `HasActiveTasks` call in `check-active` hook: single `ListTasks` query instead of two DB round-trips on every stop hook fire
- Merge two loops in `writeSnapshot` into one pass (count + categorize simultaneously)
- Remove obsolete `PendingSummary` wrapper and its test (was only used by the deleted `pendingCmd`)

## Test plan
- [x] All tests pass (`go test -count=1 ./...`)
- [x] staticcheck clean
- [x] Existing `printTask` tests in `main_test.go` still pass (they exercise `printTaskTo` through the wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)