### PR TITLE
Fix GoReleaser deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,10 +25,10 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary
- Replace deprecated `archives.format` with `archives.formats` (list)
- Replace deprecated `archives.format_overrides.format` with `archives.format_overrides.formats` (list)
- Per https://goreleaser.com/deprecations#archivesformat

## Test plan
- [ ] CI passes
- [ ] Next release build has no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)